### PR TITLE
fix: bug headingText

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -4,7 +4,7 @@ $template = 'template-parts';
 ?>
 <?php get_header(); ?>
 
-<?php  get_template_part($template . '/content-title', null, array('post_id' => $post_id, 'headingText' => get_the_archive_title())); ?>
+<?php  get_template_part($template . '/content-title', null, array('post_id' => $post_id, 'headingText' => null)); ?>
 
 <div id="content-pro" class="site-content u-mb-50px u-relative">
   <div class="l-container l-container__showLeftSidebar">

--- a/template-parts/content-title.php
+++ b/template-parts/content-title.php
@@ -22,6 +22,6 @@ $parent_class = $is_post ? 'u-mb-50px l-title' : 'u-bg-cover u-mb-50px l-title';
   </p>
   <?php else : ?>
   <h1 class="page-title c-heading__title">
-    <?php echo the_title() ?></h1>
+    <?php echo !!$headingText ? $headingText : single_cat_title() ?></h1>
   <?php endif; ?>
 </div>


### PR DESCRIPTION
役者ページで見出しがページタイトルになっているので、役者名を表示するようにする。
おそらく他のタクソノミーもなっているので合わせて修正。
