### PR TITLE
タグ一覧の表示方法を変更

### DIFF
--- a/single.php
+++ b/single.php
@@ -11,9 +11,15 @@ $heading_title = pll_current_language() === 'en' ? get_post_meta($post_id, 'orig
 get_template_part($template . '/content-title', null, array('post_id' => $post_id, 'headingText' => $heading_title, 'is_post' => 'post' == get_post_type()));
 ?>
 
-<div id="content-pro" class="site-content-blog-post u-mt-60px u-mb-50px u-relative">
+<div
+  id="content-pro"
+  class="site-content-blog-post u-mt-60px u-mb-50px u-relative"
+>
   <div class="l-container l-container__showLeftSidebar">
-    <div id="main-container-pro" class="l-content">
+    <div
+      id="main-container-pro"
+      class="l-content"
+    >
       <?php get_template_part('template-parts/date', 'single'); ?>
       <?php get_template_part('template-parts/content', 'single'); ?>
     </div><!-- close #main-container-pro -->
@@ -40,6 +46,10 @@ get_template_part($template . '/content-title', null, array('post_id' => $post_i
     <?php
       // カテゴリーにもとづくPostを表示
       get_template_part($template . '/category-posts-rand', null, array('post_id' => $post_id));
+    ?>
+    <?php
+      // タグにもとづくPostを表示
+      get_template_part($template . '/content-tag-posts', null, array('post_id' => $post_id));
     ?>
   </div>
   <div class="u-mt-10">

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -3,7 +3,10 @@ $post_id = $post->ID;
 $template = 'template-parts';
 ?>
 
-<main id="single-post-<?php echo $post_id; ?>" <?php post_class(); ?>>
+<main
+  id="single-post-<?php echo $post_id; ?>"
+  <?php post_class(); ?>
+>
   <?php get_template_part($template . '/content-review'); ?>
 
   <?php if (is_active_sidebar('progression-studios-post-widgets-top')) : ?>
@@ -42,7 +45,5 @@ $template = 'template-parts';
     <?php dynamic_sidebar('progression-studios-post-widgets-bottom'); ?>
   </div>
   <?php endif; ?>
-
-  <?php the_tags('<div class="c-tags">', '', '</div>'); ?>
 
 </main>

--- a/template-parts/content-tag-posts.php
+++ b/template-parts/content-tag-posts.php
@@ -1,0 +1,43 @@
+<?php if ('post' == get_post_type()) : ?>
+<?php
+  ['post_id' => $post_id] = $args;
+  $tags = get_the_tags($post_id);
+  $tag_ids = array();
+  ?>
+<?php if ($tags) : ?>
+<?php foreach ($tags as $tag) : ?>
+<?php
+      $tag_id = $tag->term_id;
+      $tag_name = $tag->name;
+      $tag_description = $tag->description;
+      $query_args = array(
+        'tag_id' => $tag_id,
+        'posts_per_page' => 3,
+        'post__not_in' => array($post_id),
+        'posts_per_page' => 3, // Number of related posts that will be displayed.
+        'orderby' => 'rand' // Randomize the posts
+      );
+      $tag_query = new WP_Query($query_args);
+      $class_name = count($tag_query->posts) === 3 ? 'l-postRelated__3columns' : 'l-postRelated';
+      ?>
+<?php if ($tag_query->have_posts()) : ?>
+<section class="u-mt-6">
+  <h2 class="c-heading__related u-mb-3">
+    <?php echo pll_current_language() === 'en' ? 'I recommend this ' . $tag_name . '!' : $tag_name . 'もおすすめです！' ?>
+  </h2>
+  <?php if($tag_description) : ?>
+  <p><?php echo $tag_description ?></p>
+  <?php endif; ?>
+  <ul class="<?php echo $class_name ?>">
+    <?php while ($tag_query->have_posts()) : $tag_query->the_post(); ?>
+    <li>
+      <?php get_template_part('template-parts/components/postImageOverlay'); ?>
+    </li>
+    <?php endwhile; ?>
+  </ul>
+</section>
+<?php endif; ?>
+<?php endforeach; ?>
+<?php wp_reset_postdata(); ?>
+<?php endif; ?>
+<?php endif; ?>

--- a/template-parts/content-tag-posts.php
+++ b/template-parts/content-tag-posts.php
@@ -2,7 +2,6 @@
 <?php
   ['post_id' => $post_id] = $args;
   $tags = get_the_tags($post_id);
-  $tag_ids = array();
   ?>
 <?php if ($tags) : ?>
 <?php foreach ($tags as $tag) : ?>


### PR DESCRIPTION
変更前：ポストページに表示されているタグはタグ名でリンクのみを表示していた
↓
変更後：tag_idからポスト一覧を表示する